### PR TITLE
BottomNavDestinations -> BottomNavScreenSpec

### DIFF
--- a/app/src/main/java/com/florianwalther/incentivetimer/application/ITActivity.kt
+++ b/app/src/main/java/com/florianwalther/incentivetimer/application/ITActivity.kt
@@ -1,40 +1,25 @@
 package com.florianwalther.incentivetimer.application
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.List
-import androidx.compose.material.icons.outlined.Star
-import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.florianwalther.incentivetimer.R
-import com.florianwalther.incentivetimer.core.ui.screenspecs.RewardListScreenSpec
+import com.florianwalther.incentivetimer.core.ui.screenspecs.BottomNavScreenSpec
 import com.florianwalther.incentivetimer.core.ui.screenspecs.ScreenSpec
-import com.florianwalther.incentivetimer.core.ui.screenspecs.TimerScreenSpec
 import com.florianwalther.incentivetimer.core.ui.theme.IncentiveTimerTheme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.receiveAsFlow
 
 @AndroidEntryPoint
 class ITActivity : ComponentActivity() {
@@ -69,7 +54,7 @@ private fun ScreenContent() {
 
             if (hideBottomBar == null || !hideBottomBar) {
                 BottomNavigation {
-                    bottomNavDestinations.forEach { bottomNavDestination ->
+                    BottomNavScreenSpec.screens.forEach { bottomNavDestination ->
                         BottomNavigationItem(
                             icon = {
                                 Icon(bottomNavDestination.icon, contentDescription = null)
@@ -78,12 +63,12 @@ private fun ScreenContent() {
                                 Text(stringResource(bottomNavDestination.label))
                             },
                             alwaysShowLabel = false,
-                            selected = currentDestination?.hierarchy?.any { it.route == bottomNavDestination.screenSpec.navHostRoute } == true,
+                            selected = currentDestination?.hierarchy?.any { it.route == bottomNavDestination.navHostRoute } == true,
                             onClick = {
                                 // TODO: 29/12/2021 Navigate to start destination not working after deep link -> library bug.
                                 //  Switch back to onNewIntent if bug doesn't get fixed
                                 //  Workaround: https://issuetracker.google.com/issues/194301895
-                                navController.navigate(bottomNavDestination.screenSpec.navHostRoute) {
+                                navController.navigate(bottomNavDestination.navHostRoute) {
                                     popUpTo(navController.graph.findStartDestination().id) {
                                         saveState = true
                                     }
@@ -99,7 +84,7 @@ private fun ScreenContent() {
     ) { innerPadding ->
         NavHost(
             navController = navController,
-            startDestination = bottomNavDestinations[0].screenSpec.navHostRoute,
+            startDestination = BottomNavScreenSpec.screens[0].navHostRoute,
             modifier = Modifier.padding(innerPadding),
         ) {
             ScreenSpec.allScreens.values.forEach { screen ->
@@ -124,27 +109,6 @@ fun ScreenContentPreview() {
     IncentiveTimerTheme {
         ScreenContent()
     }
-}
-
-val bottomNavDestinations = listOf<BottomNavDestinations>(
-    BottomNavDestinations.TimerScreen,
-    BottomNavDestinations.RewardListScreen
-)
-
-sealed class BottomNavDestinations(
-    val screenSpec: ScreenSpec,
-    val icon: ImageVector,
-    @StringRes val label: Int
-) {
-    object TimerScreen :
-        BottomNavDestinations(screenSpec = TimerScreenSpec, Icons.Outlined.Timer, R.string.timer)
-
-    object RewardListScreen :
-        BottomNavDestinations(
-            screenSpec = RewardListScreenSpec,
-            Icons.Outlined.Star,
-            R.string.rewards
-        )
 }
 
 const val ARG_HIDE_BOTTOM_BAR = "ARG_HIDE_BOTTOM_BAR"

--- a/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/AddEditRewardScreenSpec.kt
+++ b/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/AddEditRewardScreenSpec.kt
@@ -18,6 +18,10 @@ import com.florianwalther.incentivetimer.features.rewards.addeditreward.*
 import kotlinx.coroutines.flow.collect
 
 object AddEditRewardScreenSpec : ScreenSpec {
+
+    private const val ARG_REWARD_ID = "rewardId"
+    private const val NO_REWARD_ID = -1L
+
     override val navHostRoute: String = "add_edit_reward?$ARG_REWARD_ID={$ARG_REWARD_ID}"
 
     override val arguments: List<NamedNavArgument>
@@ -101,6 +105,3 @@ object AddEditRewardScreenSpec : ScreenSpec {
         )
     }
 }
-
-private const val ARG_REWARD_ID = "rewardId"
-const val NO_REWARD_ID = -1L

--- a/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/BottomNavScreenSpec.kt
+++ b/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/BottomNavScreenSpec.kt
@@ -1,0 +1,20 @@
+package com.florianwalther.incentivetimer.core.ui.screenspecs
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.vector.ImageVector
+
+sealed interface BottomNavScreenSpec : ScreenSpec {
+
+    companion object {
+        val screens: List<BottomNavScreenSpec> = ScreenSpec
+            .allScreens
+            .values
+            .filterIsInstance<BottomNavScreenSpec>()
+    }
+
+    val icon: ImageVector
+
+    @get:StringRes
+    val label: Int
+
+}

--- a/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/RewardListScreenSpec.kt
+++ b/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/RewardListScreenSpec.kt
@@ -1,11 +1,14 @@
 package com.florianwalther.incentivetimer.core.ui.screenspecs
 
 import androidx.compose.material.SnackbarResult
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
@@ -23,7 +26,12 @@ import com.florianwalther.incentivetimer.features.rewards.rewardlist.RewardListS
 import com.florianwalther.incentivetimer.features.rewards.rewardlist.RewardListViewModel
 import kotlinx.coroutines.flow.collectLatest
 
-object RewardListScreenSpec : ScreenSpec {
+object RewardListScreenSpec : BottomNavScreenSpec {
+
+    override val icon: ImageVector = Icons.Outlined.Star
+
+    override val label: Int = R.string.rewards
+
     override val navHostRoute: String = "reward_list"
 
     override val deepLinks: List<NavDeepLink> = listOf(

--- a/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/ScreenSpec.kt
+++ b/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/ScreenSpec.kt
@@ -1,12 +1,10 @@
 package com.florianwalther.incentivetimer.core.ui.screenspecs
 
-import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.navigation.NamedNavArgument
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavDeepLink
-import com.florianwalther.incentivetimer.R
 
 sealed interface ScreenSpec {
 

--- a/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/TimerScreenSpec.kt
+++ b/app/src/main/java/com/florianwalther/incentivetimer/core/ui/screenspecs/TimerScreenSpec.kt
@@ -1,18 +1,27 @@
 package com.florianwalther.incentivetimer.core.ui.screenspecs
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavDeepLink
 import androidx.navigation.navDeepLink
+import com.florianwalther.incentivetimer.R
 import com.florianwalther.incentivetimer.features.timer.TimerScreenContent
 import com.florianwalther.incentivetimer.features.timer.TimerScreenAppBar
 import com.florianwalther.incentivetimer.features.timer.TimerViewModel
 
-object TimerScreenSpec : ScreenSpec {
+object TimerScreenSpec : BottomNavScreenSpec {
+
+    override val icon: ImageVector = Icons.Outlined.Timer
+
+    override val label: Int = R.string.timer
+
     override val navHostRoute: String = "timer"
 
     override val deepLinks: List<NavDeepLink> = listOf(


### PR DESCRIPTION
Suggestion: Remove BottomNavDestinations in favour of a BottomNavScreenSpec sealed interface child of ScreenSpec.

Just wanted to show you what I meant back then when you implemented the `ScreenSpec` approach :) I know you have changes not pushed, but this should be enough to show you the general idea.
Then you can check it and implement it yourself if you want to 🙂 

Keep up the good work!

Rafael